### PR TITLE
Check if meshes are empty

### DIFF
--- a/apps/infer.py
+++ b/apps/infer.py
@@ -543,25 +543,26 @@ if __name__ == "__main__":
 
                 # only face
                 face_mesh = apply_vertex_mask(face_mesh, SMPLX_object.front_flame_vertex_mask)
-                face_mesh.vertices = face_mesh.vertices - np.array([0, 0, cfg.bni.thickness])
 
-                # remove face neighbor triangles
-                BNI_object.F_B_trimesh = part_removal(
-                    BNI_object.F_B_trimesh,
-                    face_mesh,
-                    cfg.bni.face_thres,
-                    device,
-                    smplx_mesh,
-                    region="face"
-                )
-                side_mesh = part_removal(
-                    side_mesh, face_mesh, cfg.bni.face_thres, device, smplx_mesh, region="face"
-                )
-                face_mesh.export(f"{args.out_dir}/{cfg.name}/obj/{data['name']}_{idx}_face.obj")
-                full_lst += [face_mesh]
+                if not face_mesh.is_empty:
+                    face_mesh.vertices = face_mesh.vertices - np.array([0, 0, cfg.bni.thickness])
+
+                    # remove face neighbor triangles
+                    BNI_object.F_B_trimesh = part_removal(
+                        BNI_object.F_B_trimesh,
+                        face_mesh,
+                        cfg.bni.face_thres,
+                        device,
+                        smplx_mesh,
+                        region="face"
+                    )
+                    side_mesh = part_removal(
+                        side_mesh, face_mesh, cfg.bni.face_thres, device, smplx_mesh, region="face"
+                    )
+                    face_mesh.export(f"{args.out_dir}/{cfg.name}/obj/{data['name']}_{idx}_face.obj")
+                    full_lst += [face_mesh]
 
             if "hand" in cfg.bni.use_smpl:
-
                 hand_mask = torch.zeros(SMPLX_object.smplx_verts.shape[0], )
 
                 if data['hands_visibility'][idx][0]:
@@ -589,20 +590,21 @@ if __name__ == "__main__":
                 # only hands
                 hand_mesh = apply_vertex_mask(hand_mesh, hand_mask)
 
-                # remove hand neighbor triangles
-                BNI_object.F_B_trimesh = part_removal(
-                    BNI_object.F_B_trimesh,
-                    hand_mesh,
-                    cfg.bni.hand_thres,
-                    device,
-                    smplx_mesh,
-                    region="hand"
-                )
-                side_mesh = part_removal(
-                    side_mesh, hand_mesh, cfg.bni.hand_thres, device, smplx_mesh, region="hand"
-                )
-                hand_mesh.export(f"{args.out_dir}/{cfg.name}/obj/{data['name']}_{idx}_hand.obj")
-                full_lst += [hand_mesh]
+                if not hand_mesh.is_empty:
+                    # remove hand neighbor triangles
+                    BNI_object.F_B_trimesh = part_removal(
+                        BNI_object.F_B_trimesh,
+                        hand_mesh,
+                        cfg.bni.hand_thres,
+                        device,
+                        smplx_mesh,
+                        region="hand"
+                    )
+                    side_mesh = part_removal(
+                        side_mesh, hand_mesh, cfg.bni.hand_thres, device, smplx_mesh, region="hand"
+                    )
+                    hand_mesh.export(f"{args.out_dir}/{cfg.name}/obj/{data['name']}_{idx}_hand.obj")
+                    full_lst += [hand_mesh]
 
             full_lst += [BNI_object.F_B_trimesh]
 


### PR DESCRIPTION
This image lead to error,  because hand or face mesh can be empty. This pull request contains checks if any of hand or face  mesh is empty.

![Doctor](https://github.com/YuliangXiu/ECON/assets/17554646/baebf74f-2b5d-40a6-be38-43babc2102bb)

```
python -m apps.infer -cfg ./configs/econ.yaml -in_dir ./examples -out_dir ./results -novis
```

```
Traceback (most recent call last):
  File ".../envs/.../lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File ".../envs/.../lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File ".../ECON/apps/infer.py", line 595, in <module>
    BNI_object.F_B_trimesh = part_removal(
  File ".../ECON/lib/dataset/mesh_util.py", line 270, in part_removal
    (part_dist, _) = part_extractor.query(torch.tensor(full_mesh.vertices).unsqueeze(0).to(device))
  File ".../ECON/lib/dataset/PointFeat.py", line 39, in query
    residues, pts_ind = point_mesh_distance(self.mesh, Pointclouds(points), weighted=False)
  File ".../ECON/lib/dataset/Evaluator.py", line 213, in point_mesh_distance
    verts_packed = meshes.verts_packed()
  File ".../envs/.../lib/python3.9/site-packages/pytorch3d/structures/meshes.py", line 563, in verts_packed
    self._compute_packed()
  File ".../envs/.../lib/python3.9/site-packages/pytorch3d/structures/meshes.py", line 974, in _compute_packed
    verts_list = self.verts_list()
  File ".../envs/.../lib/python3.9/site-packages/pytorch3d/structures/meshes.py", line 535, in verts_list
    self._verts_list = struct_utils.padded_to_list(
  File ".../envs/.../lib/python3.9/site-packages/pytorch3d/structures/utils.py", line 106, in padded_to_list
    raise ValueError("Split size must be of same length as inputs first dimension")
ValueError: Split size must be of same length as inputs first dimension
```
